### PR TITLE
Keep expiring_objects account in the collect files

### DIFF
--- a/caretaker/accounts.py
+++ b/caretaker/accounts.py
@@ -77,10 +77,6 @@ def collect(device_dir='/srv/node', stale_reads_ok=False,
             info = broker.get_info()
             meta = broker.metadata
 
-            # This account is used by the object expirer
-            if info['account'] == '.expiring_objects':
-                continue
-
             account = {'account': info['account'],
                        'domain_name': STATUS_UNKNOWN,
                        'project_id': info['account'].lstrip(reseller_prefix),
@@ -115,6 +111,11 @@ def merge(contents):
         if line:
             i += 1
             account = _construct(line)
+
+            # This account is used by the object expirer
+            if account['account'] == '.expiring_objects':
+                continue
+
             # Only collect the IDs to skip duplicates
             accounts[account['account']] = account
 


### PR DESCRIPTION
Keeping the expiring_objects account for cross checking purpose, e.g check how many management overhead capacity is utilised by that feature.
They are now skipped in the merged step instead.