### PR TITLE
Swift account black and whitelisting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,32 @@
 # swift-account-caretaker
+Swift account maintenance workflows like collecting stats or setting account ratelimits.
+
+# Binaries
+
+## swift-account-caretaker
 Collecting and merging swift account stats on swift account servers for the purpose of cleaning up orphaned accounts
 without a corresponding keystone project.
 
-# How it works
+## swift-account-ratelimit
+Quickly blacklist or whitelist an account with the internal client
+(https://docs.openstack.org/swift/latest/ratelimit.html#black-white-listing).
+
+```
+# Get Account ratelimit setting
+swift-account-ratelimit --account AUTH_123
+
+# Blacklist Account
+swift-account-ratelimit --account AUTH_123 --blacklist
+
+# Whitelist Account
+swift-account-ratelimit --account AUTH_123 --whitelist
+
+# remove Account ratelimit setting
+swift-account-ratelimit --account AUTH_123 --remove
+
+```
+
+# Caretaker - How it works
 
 ## Phase 1 - Collect
 In order to get a list of all known swift accounts, one need to ask swift itself to collect this list. Doing a project

--- a/bin/swift-account-ratelimit
+++ b/bin/swift-account-ratelimit
@@ -1,0 +1,66 @@
+#!/usr/bin/python
+
+# Copyright 2018 SAP SE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+from swift.common.internal_client import InternalClient
+import sys
+
+RATELIMIT_HEADER = "X-Account-Sysmeta-Global-Write-Ratelimit"
+
+
+def check_header(clnt, account, details=False):
+    print("Reading meta data for Account %s" % account)
+    meta = clnt.get_account_metadata(account)
+
+    if details:
+        for key, value in meta.iteritems():
+            print("\t%s: %s" % (key, value))
+        print("")
+
+    if RATELIMIT_HEADER.lower() in meta:
+        print("%s: %s" % (RATELIMIT_HEADER, meta[RATELIMIT_HEADER.lower()]))
+    else:
+        print("%s not set" % RATELIMIT_HEADER)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Global rate limit processing for swift account')
+    parser.add_argument('-a', '--account', required=True, help='Account ID')
+    parser.add_argument('-c', '--config',
+                        default='/etc/swift/internal-client.conf',
+                        help='Path to internal-client.conf.')
+    parser.add_argument('-d', '--details', action="store_true", help='Show all account meta details')
+    parser.add_argument('-r', '--remove', action="store_true", help='Remove ratelimit for account')
+    parser.add_argument('-b', '--blacklist', action="store_true", help='BLACKLIST account')
+    parser.add_argument('-w', '--whitelist', action="store_true", help='WHITELIST account')
+
+    args = parser.parse_args(sys.argv[1:])
+
+    client = InternalClient(args.config, "ratelimit/v0.0.1", 3)
+
+    check_header(client, args.account, args.details)
+
+    if args.remove or args.blacklist or args.whitelist:
+        ratelimit = ''
+        if args.blacklist:
+            ratelimit = "BLACKLIST"
+        elif args.whitelist:
+            ratelimit = "WHITELIST"
+
+        print("Setting header to '%s'" % ratelimit)
+        client.set_account_metadata(args.account, {RATELIMIT_HEADER: ratelimit})
+
+        check_header(client, args.account)

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ packages =
     caretaker
 scripts =
     bin/swift-account-caretaker
+    bin/swift-account-ratelimit
 
 [global]
 setup-hooks =


### PR DESCRIPTION
Quickly blacklist or whitelist an account with the internal client
(https://docs.openstack.org/swift/latest/ratelimit.html#black-white-listing).